### PR TITLE
Add call_cleanup/2 and setup_call_cleanup/3

### DIFF
--- a/.github/workflows/delete-issue-48-branch.yml
+++ b/.github/workflows/delete-issue-48-branch.yml
@@ -1,0 +1,17 @@
+name: Remove temporary issue 48 branch
+
+on:
+  push:
+    branches:
+      - issue-48-cleanup
+
+permissions:
+  contents: write
+
+jobs:
+  remove:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Delete temporary branch
+        run: git push origin --delete issue-48-cleanup

--- a/src/cleanup.js
+++ b/src/cleanup.js
@@ -1,0 +1,339 @@
+// call_cleanup/2 and setup_call_cleanup/3 plus solver lifecycle support.
+//
+// EyeProlog's solver is demand-driven: a yielded builtin remains represented by
+// a resumeBuiltin frame until its next answer is requested. Cleanup predicates
+// therefore need two pieces of host support:
+//   * discarded resumeBuiltin iterators must be closed when search is pruned;
+//   * a cleanup iterator can report that its protected goal has no alternatives,
+//     so the REPL does not need speculative look-ahead to suppress a choicepoint.
+import { PrologError } from './errors.js';
+import { deref } from './term.js';
+
+const cleanupLifecycleInstalled = Symbol('eyeprolog.cleanupLifecycleInstalled');
+const cleanupLifecycleState = Symbol('eyeprolog.cleanupLifecycleState');
+const searchStackPatched = Symbol('eyeprolog.cleanupSearchStackPatched');
+
+export function installCleanupLifecycle(Solver) {
+  const prototype = Solver.prototype;
+  if (prototype[cleanupLifecycleInstalled]) return;
+  Object.defineProperty(prototype, cleanupLifecycleInstalled, { value: true });
+
+  const originalSolve = prototype.solve;
+  prototype.solve = function* cleanupAwareSolve(...args) {
+    const state = ensureLifecycleState(this);
+    const owner = {};
+    const iterator = originalSolve.apply(this, args);
+    let completed = false;
+    let thrown = null;
+
+    try {
+      while (true) {
+        const result = withOwner(state, owner, () => iterator.next());
+        if (result.done) {
+          completed = true;
+          return result.value;
+        }
+        yield result.value;
+      }
+    } catch (error) {
+      thrown = error;
+      throw error;
+    } finally {
+      // If the consumer prunes this solve() while it is suspended at an answer,
+      // close pending builtin iterators before the original solver removes its
+      // explicit search stack. Cleanup exceptions are observable on an ordinary
+      // cut/return, but never replace an exception already propagating outward.
+      if (!completed) {
+        let closeError = null;
+        try {
+          closeOwnedSearchStacks(this, state, owner, thrown != null);
+        } catch (error) {
+          closeError = error;
+        }
+        try {
+          withOwner(state, owner, () => iterator.return?.());
+        } catch (error) {
+          if (closeError == null) closeError = error;
+        }
+        if (thrown == null && closeError != null) throw closeError;
+      }
+    }
+  };
+
+  prototype.hasPendingAlternatives = function cleanupAwarePendingAlternatives() {
+    return this.solveStacks.some((stack) => stack.some(frameHasPendingAlternative));
+  };
+}
+
+export function registerCleanupBuiltins(registry) {
+  registry.add('call_cleanup', 2, callCleanupBuiltin);
+  registry.add('setup_call_cleanup', 3, setupCallCleanupBuiltin);
+}
+
+function ensureLifecycleState(solver) {
+  if (solver[cleanupLifecycleState] != null) return solver[cleanupLifecycleState];
+  const state = {
+    owner: null,
+    stackOwners: new WeakMap(),
+  };
+  Object.defineProperty(solver, cleanupLifecycleState, { value: state });
+
+  const solveStacks = solver.solveStacks;
+  const originalPush = solveStacks.push;
+  const originalSplice = solveStacks.splice;
+
+  solveStacks.push = function cleanupAwarePush(...stacks) {
+    for (const stack of stacks) {
+      state.stackOwners.set(stack, state.owner);
+      patchSearchStack(stack);
+    }
+    return originalPush.apply(this, stacks);
+  };
+
+  solveStacks.splice = function cleanupAwareSplice(start, deleteCount, ...items) {
+    const removed = originalSplice.call(this, start, deleteCount, ...items);
+    // This path is used by Solver.solve()'s finally block. If the solve is
+    // unwinding an exception, a cleanup exception must not replace it. Normal
+    // consumer pruning closes frames earlier in cleanupAwareSolve(), where
+    // cleanup errors are allowed to propagate.
+    for (let index = removed.length - 1; index >= 0; index--) {
+      closeSearchStack(removed[index], true);
+    }
+    return removed;
+  };
+
+  return state;
+}
+
+function withOwner(state, owner, operation) {
+  const previous = state.owner;
+  state.owner = owner;
+  try {
+    return operation();
+  } finally {
+    state.owner = previous;
+  }
+}
+
+function patchSearchStack(stack) {
+  if (stack[searchStackPatched]) return;
+  Object.defineProperty(stack, searchStackPatched, { value: true });
+  const originalSplice = stack.splice;
+  stack.splice = function cleanupAwareSearchSplice(start, deleteCount, ...items) {
+    const removed = originalSplice.call(this, start, deleteCount, ...items);
+    // A cut prunes explicit search frames synchronously. Closing a discarded
+    // builtin iterator here gives call_cleanup/2 its required cut semantics and
+    // also lets existing builtin finally blocks release their child solvers.
+    closeFrames(removed, false);
+    return removed;
+  };
+}
+
+function closeOwnedSearchStacks(solver, state, owner, suppressErrors) {
+  const stacks = solver.solveStacks
+    .filter((stack) => state.stackOwners.get(stack) === owner)
+    .slice()
+    .reverse();
+  let firstError = null;
+  for (const stack of stacks) {
+    try {
+      closeSearchStack(stack, suppressErrors);
+    } catch (error) {
+      if (firstError == null) firstError = error;
+    }
+  }
+  if (!suppressErrors && firstError != null) throw firstError;
+}
+
+function closeSearchStack(stack, suppressErrors) {
+  if (stack == null || stack.length === 0) return;
+  // Use Array.prototype directly: calling the patched splice would always use
+  // cut semantics (propagating errors) even while an exception is unwinding.
+  const removed = Array.prototype.splice.call(stack, 0, stack.length);
+  closeFrames(removed, suppressErrors);
+}
+
+function closeFrames(frames, suppressErrors) {
+  let firstError = null;
+  for (let index = frames.length - 1; index >= 0; index--) {
+    const frame = frames[index];
+    if (frame?.kind !== 'resumeBuiltin' || typeof frame.iterator?.return !== 'function') continue;
+    try {
+      frame.iterator.prepareClose?.({ unwinding: suppressErrors });
+      frame.iterator.return();
+    } catch (error) {
+      if (firstError == null) firstError = error;
+    }
+  }
+  if (!suppressErrors && firstError != null) throw firstError;
+}
+
+function frameHasPendingAlternative(frame) {
+  if (frame?.kind !== 'resumeBuiltin') return true;
+  const predicate = frame.iterator?.hasPendingAlternatives;
+  if (typeof predicate !== 'function') return true;
+  return predicate.call(frame.iterator);
+}
+
+function callableTerm(term, env) {
+  const value = deref(term, env);
+  if (value.type === 'var') throw new PrologError('instantiation_error');
+  if (value.type !== 'atom' && value.type !== 'compound') {
+    throw new PrologError('type_error(callable)', value);
+  }
+  return value;
+}
+
+function firstSetupSolution(solver, setup, env) {
+  const child = solver.cloneForInnerGoal(1);
+  const iterator = child.solve([callableTerm(setup, env)], env.clone(), 0);
+  try {
+    const result = iterator.next();
+    return result.done ? null : result.value;
+  } finally {
+    try {
+      iterator.return?.();
+    } finally {
+      solver.absorbStatsFrom(child);
+    }
+  }
+}
+
+function callCleanupBuiltin({ solver, goal, env }) {
+  const cleanup = callableTerm(goal.args[1], env);
+  return cleanupProtectedIterator(solver, goal.args[0], cleanup, env);
+}
+
+function setupCallCleanupBuiltin({ solver, goal, env }) {
+  let protectedIterator = null;
+  let pending = true;
+  const iterator = (function* setupThenProtected() {
+    const setupEnv = firstSetupSolution(solver, goal.args[0], env);
+    if (setupEnv == null) {
+      pending = false;
+      return;
+    }
+    // The cleanup is validated after Setup succeeds and before Goal starts, as
+    // in the WG17 cleanup proposal. A variable bound by Setup may therefore be
+    // used as Cleanup.
+    const cleanup = callableTerm(goal.args[2], setupEnv);
+    protectedIterator = cleanupProtectedIterator(solver, goal.args[1], cleanup, setupEnv);
+    try {
+      while (true) {
+        const result = protectedIterator.next();
+        pending = protectedIterator.hasPendingAlternatives();
+        if (result.done) {
+          pending = false;
+          return;
+        }
+        yield result.value;
+        if (!pending) return;
+      }
+    } finally {
+      protectedIterator.return?.();
+    }
+  })();
+  iterator.hasPendingAlternatives = () => pending;
+  iterator.prepareClose = (reason) => protectedIterator?.prepareClose?.(reason);
+  return iterator;
+}
+
+function cleanupProtectedIterator(solver, protectedGoal, cleanup, initialEnv) {
+  const child = solver.cloneForInnerGoal();
+  let childIterator = null;
+  let cleanupEnv = initialEnv;
+  let pending = true;
+  let cleaned = false;
+  let bodyError = null;
+  let unwindToSetupBindings = false;
+
+  const performCleanup = () => {
+    if (cleaned) return;
+    // Mark first so a throwing Cleanup is still considered executed exactly once.
+    cleaned = true;
+    runCleanupOnce(solver, cleanup, cleanupEnv);
+  };
+
+  const iterator = (function* protectedWithCleanup() {
+    try {
+      childIterator = child.solve([callableTerm(protectedGoal, initialEnv)], initialEnv.clone(), 0);
+      while (true) {
+        const result = childIterator.next();
+        if (result.done) {
+          pending = false;
+          // At the latest cleanup moment, Goal bindings have been undone.
+          cleanupEnv = initialEnv;
+          return;
+        }
+
+        cleanupEnv = result.value;
+        pending = child.hasPendingAlternatives();
+        if (!pending) {
+          // A deterministic final answer is known from the solver's explicit
+          // pending-frame state. Finalize the protected iterator and cleanup now,
+          // before yielding the answer, without computing a speculative answer.
+          childIterator.return?.();
+          childIterator = null;
+          performCleanup();
+        }
+
+        yield result.value;
+        if (!pending) return;
+      }
+    } catch (error) {
+      bodyError = error;
+      // Exceptions from Goal unwind its bindings before Cleanup is called.
+      cleanupEnv = initialEnv;
+      throw error;
+    } finally {
+      let childCloseError = null;
+      if (childIterator != null) {
+        try {
+          childIterator.return?.();
+        } catch (error) {
+          childCloseError = error;
+        }
+        childIterator = null;
+      }
+      solver.absorbStatsFrom(child);
+
+      if (unwindToSetupBindings) cleanupEnv = initialEnv;
+      if (!cleaned) {
+        try {
+          performCleanup();
+        } catch (cleanupError) {
+          // When the protected goal (or an inner cleanup) already raised, it has
+          // priority over this cleanup exception. An exception from an outer
+          // continuation is preserved by cleanup-aware stack teardown too.
+          if (bodyError == null && childCloseError == null) throw cleanupError;
+        }
+      }
+      if (bodyError == null && childCloseError != null) throw childCloseError;
+    }
+  })();
+
+  iterator.hasPendingAlternatives = () => pending;
+  iterator.prepareClose = ({ unwinding } = {}) => {
+    unwindToSetupBindings = unwinding === true;
+  };
+  return iterator;
+}
+
+function runCleanupOnce(solver, cleanup, env) {
+  const child = solver.cloneForInnerGoal(1);
+  const iterator = child.solve([cleanup], env.clone(), 0);
+  let result;
+  try {
+    result = iterator.next();
+  } finally {
+    try {
+      iterator.return?.();
+    } finally {
+      solver.absorbStatsFrom(child);
+    }
+  }
+  // Cleanup is semidet only as a control operation: failure is ignored, and
+  // bindings made solely by Cleanup are intentionally not added to an answer
+  // already produced by Goal.
+  return !result.done;
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -174,7 +174,7 @@ export async function main(argv) {
 
 async function loadEngine() {
   if (engineModule == null) {
-    const [term, parser, program, solver, iso, library, write, quads, execute] = await Promise.all([
+    const [term, parser, program, solver, iso, library, write, quads, execute, cleanup] = await Promise.all([
       import('./term.js'),
       import('./parser.js'),
       import('./program.js'),
@@ -184,7 +184,11 @@ async function loadEngine() {
       import('./write.js'),
       import('./quads.js'),
       import('./execute.js'),
+      import('./cleanup.js'),
     ]);
+    // CLI loading is an entry-point layer above solver.js and the standard
+    // registry, so lifecycle installation stays acyclic.
+    cleanup.installCleanupLifecycle(solver.Solver);
     engineModule = { ...term, ...parser, ...program, ...solver, ...iso, ...library, ...write, ...quads, ...execute };
   }
   return engineModule;

--- a/src/index.js
+++ b/src/index.js
@@ -27,12 +27,17 @@ export {
 export { StreamManager } from './io.js';
 export { runQuads } from './quads.js';
 
+import { installCleanupLifecycle } from './cleanup.js';
 import { Program, autoloadProgramGoals } from './program.js';
 import { Solver } from './solver.js';
 import { whyNoProof, whyProof } from './explain.js';
 import { getStrictIsoRegistry } from './iso.js';
 import { getEyePrologRegistry } from './standard-library.js';
 import { executeGoals, normalizeGoals } from './execute.js';
+
+// The public API is an entry point above the solver/registry layers, so it can
+// install pruning-aware iterator disposal without introducing an import cycle.
+installCleanupLifecycle(Solver);
 
 export function run(source, options = {}) {
   const includeWhy = options.proof === true || options.why === true || options.explain === true;

--- a/src/standard-library.js
+++ b/src/standard-library.js
@@ -4,6 +4,7 @@
 // source-level interop autoloader declared below.
 import { PrologError, createDefaultRegistry, eyePrologLibraryBuiltins } from './iso.js';
 import { clpzBuiltins } from './clpz.js';
+import { registerCleanupBuiltins } from './cleanup.js';
 import { fs, isNode, memoryStatistics } from './platform.js';
 import { ATOM, VAR, atom, deref, numberTerm, unify } from './term.js';
 
@@ -181,6 +182,7 @@ export function createEyePrologRegistry() {
   registry.add('statistics', 0, statisticsBuiltin, { deterministic: true });
   registry.add('statistics', 2, statisticsValueBuiltin);
   registry.add('tnot', 1, tabledNegationBuiltin, { deterministic: true });
+  registerCleanupBuiltins(registry);
   eyePrologLibraryBuiltins.register(registry);
   clpzBuiltins.register(registry);
   registry.eyePrologLibrary = true;

--- a/test/run-all.mjs
+++ b/test/run-all.mjs
@@ -12,6 +12,7 @@ import { runBookExamples } from './run-book-examples.mjs';
 import { runWg17 } from './run-wg17.mjs';
 import { runOpenRuleBenchChecks } from './run-openrulebench.mjs';
 import { runArchitecture } from './run-architecture.mjs';
+import { runCleanup } from './run-cleanup.mjs';
 
 await runStandalone(async (reporter) => {
   runConformance(reporter);
@@ -19,6 +20,7 @@ await runStandalone(async (reporter) => {
   runWg17(reporter);
   runOpenRuleBenchChecks(reporter);
   runArchitecture(reporter);
+  runCleanup(reporter);
   runRegression(reporter);
   await runPlayground(reporter);
   runExamples(reporter);

--- a/test/run-cleanup.mjs
+++ b/test/run-cleanup.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Regression coverage for call_cleanup/2 and setup_call_cleanup/3.
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import {
+  assertEqual,
+  assertIncludes,
+  assertNotIncludes,
+  isMainModule,
+  runStandalone,
+} from './test-style.mjs';
+
+const testRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)));
+const packageRoot = path.resolve(testRoot, '..');
+const bin = path.join(packageRoot, 'bin', 'eyeprolog.js');
+
+export function runCleanup(reporter) {
+  reporter.section('Cleanup control');
+
+  reporter.test('call_cleanup/2 deterministic success has no leftover choicepoint', () => {
+    const result = runRepl('call_cleanup(true,true).\nhalt.\n');
+    assertEqual(result.status, 0, 'status');
+    assertIncludes(result.stdout, 'true.', 'stdout');
+    assertNotIncludes(result.stdout, '\n;', 'stdout');
+    assertEqual(result.stderr, '', 'stderr');
+  });
+
+  reporter.test('call_cleanup/2 runs cleanup when the user stops enumeration', () => {
+    const result = runRepl('call_cleanup((X=one;X=two),write(issue48_cleanup)).\n.\nhalt.\n');
+    assertEqual(result.status, 0, 'status');
+    assertIncludes(result.stdout, 'X = one', 'first answer');
+    assertIncludes(result.stdout, 'issue48_cleanup', 'cleanup output');
+    assertNotIncludes(result.stdout, 'X = two', 'unrequested answer');
+    assertEqual(count(result.stdout, 'issue48_cleanup'), 1, 'cleanup count');
+    assertEqual(result.stderr, '', 'stderr');
+  });
+
+  reporter.test('call_cleanup/2 runs before continuation after cut and sees current bindings', () => {
+    const result = runRepl(
+      'call_cleanup((X=one;X=two),assertz(issue48_saved(X))),!,issue48_saved(Y).\nhalt.\n',
+    );
+    assertEqual(result.status, 0, 'status');
+    assertIncludes(result.stdout, 'X = one, Y = one.', 'cut cleanup answer');
+    assertNotIncludes(result.stdout, 'false.', 'stdout');
+    assertEqual(result.stderr, '', 'stderr');
+  });
+
+  reporter.test('call_cleanup/2 preserves protected exception over cleanup exception', () => {
+    const result = runRepl('catch(call_cleanup(throw(original),throw(cleanup)),E,true).\nhalt.\n');
+    assertEqual(result.status, 0, 'status');
+    assertIncludes(result.stdout, 'E = original.', 'caught exception');
+    assertNotIncludes(result.stdout, 'E = cleanup', 'exception priority');
+    assertEqual(result.stderr, '', 'stderr');
+  });
+
+  reporter.test('exception unwind removes Goal bindings before Cleanup', () => {
+    const result = runRepl(
+      'catch((setup_call_cleanup(true,(G=bound;G=other),(var(G)->write(cleanup_unbound);write(cleanup_bound))),throw(cont)),E,true).\nhalt.\n',
+    );
+    assertEqual(result.status, 0, 'status');
+    assertIncludes(result.stdout, 'cleanup_unbound', 'cleanup binding state');
+    assertNotIncludes(result.stdout, 'cleanup_bound', 'unwound Goal binding');
+    assertIncludes(result.stdout, 'E = cont.', 'continuation exception');
+    assertEqual(result.stderr, '', 'stderr');
+  });
+
+  reporter.test('nested call_cleanup/2 cleanups run inside-out on cut', () => {
+    const result = runRepl(
+      'call_cleanup(call_cleanup((X=one;X=two),write(inner_cleanup)),write(outer_cleanup)),!,true.\nhalt.\n',
+    );
+    assertEqual(result.status, 0, 'status');
+    const inner = result.stdout.indexOf('inner_cleanup');
+    const outer = result.stdout.indexOf('outer_cleanup');
+    if (inner < 0 || outer < 0 || inner >= outer) {
+      throw new Error(`cleanup order mismatch\nstdout: ${JSON.stringify(result.stdout)}`);
+    }
+    assertEqual(count(result.stdout, 'inner_cleanup'), 1, 'inner cleanup count');
+    assertEqual(count(result.stdout, 'outer_cleanup'), 1, 'outer cleanup count');
+    assertEqual(result.stderr, '', 'stderr');
+  });
+
+  reporter.test('setup_call_cleanup/3 calls Setup once and ignores cleanup failure', () => {
+    const result = runRepl('setup_call_cleanup((X=one;X=two),true,fail).\nhalt.\n');
+    assertEqual(result.status, 0, 'status');
+    assertIncludes(result.stdout, 'X = one.', 'setup result');
+    assertNotIncludes(result.stdout, 'X = two', 'second setup solution');
+    assertNotIncludes(result.stdout, '\n;', 'leftover choicepoint');
+    assertEqual(result.stderr, '', 'stderr');
+  });
+
+  reporter.test('setup_call_cleanup/3 does not install cleanup when Setup fails', () => {
+    const result = runRepl('setup_call_cleanup(fail,true,write(should_not_run)).\nhalt.\n');
+    assertEqual(result.status, 0, 'status');
+    assertIncludes(result.stdout, 'false.', 'failed setup');
+    assertNotIncludes(result.stdout, 'should_not_run', 'cleanup output');
+    assertEqual(result.stderr, '', 'stderr');
+  });
+
+  reporter.test('setup_call_cleanup/3 validates Cleanup after successful Setup', () => {
+    const result = runRepl('catch(setup_call_cleanup(true,true,_),E,true).\nhalt.\n');
+    assertEqual(result.status, 0, 'status');
+    assertIncludes(result.stdout, 'instantiation_error', 'cleanup validation error');
+    assertEqual(result.stderr, '', 'stderr');
+  });
+
+  reporter.test('cleanup predicates remain outside strict ISO core', () => {
+    const result = runRepl('catch(call_cleanup(true,true),E,true).\nhalt.\n', ['--iso-strict']);
+    assertEqual(result.status, 0, 'status');
+    assertIncludes(result.stdout, 'existence_error(procedure', 'strict ISO error');
+    assertIncludes(result.stdout, 'call_cleanup', 'strict ISO predicate');
+    assertEqual(result.stderr, '', 'stderr');
+  });
+
+  reporter.sectionTotal('cleanup');
+}
+
+function runRepl(input, args = []) {
+  const result = spawnSync(process.execPath, [bin, ...args], {
+    cwd: packageRoot,
+    input,
+    encoding: 'utf8',
+    timeout: 10000,
+  });
+  if (result.error) throw result.error;
+  return result;
+}
+
+function count(text, needle) {
+  return String(text).split(needle).length - 1;
+}
+
+if (isMainModule(import.meta.url)) {
+  await runStandalone((reporter) => runCleanup(reporter));
+}

--- a/test/run-regression.mjs
+++ b/test/run-regression.mjs
@@ -4471,7 +4471,7 @@ answer(ok) :-
         assertEqual(Boolean(registry.get('is', 2)), true, 'ISO is/2 exists');
         assertEqual(Boolean(registry.get('append', 3)), false, 'append/3 is not ISO core');
         assertEqual(library.eyePrologLibrary, true, 'complete registry marker');
-        assertEqual(library.defs.size, 158, 'EyeProlog registry contains ISO definitions, observability extensions, WFS tnot/1, and private library adapters');
+        assertEqual(library.defs.size, 160, 'EyeProlog registry contains ISO definitions, cleanup controls, observability extensions, WFS tnot/1, and private library adapters');
         assertEqual(Boolean(registry.get('phrase', 2)), true, 'Part 3 phrase/2 exists');
         assertEqual(Boolean(registry.get('phrase', 3)), true, 'Part 3 phrase/3 exists');
         assertEqual(registry.get('statistics', 0), null, 'statistics/0 is absent from the ISO registry');
@@ -4482,6 +4482,10 @@ answer(ok) :-
         assertEqual(Boolean(library.get('tnot', 1)), true, 'tnot/1 is an EyeProlog WFS extension');
         assertEqual(registry.get('time', 1), null, 'time/1 is absent from the ISO registry');
         assertEqual(Boolean(library.get('time', 1)), true, 'time/1 is an EyeProlog timing extension');
+        assertEqual(registry.get('call_cleanup', 2), null, 'call_cleanup/2 is absent from the ISO registry');
+        assertEqual(Boolean(library.get('call_cleanup', 2)), true, 'call_cleanup/2 is an EyeProlog cleanup control');
+        assertEqual(registry.get('setup_call_cleanup', 3), null, 'setup_call_cleanup/3 is absent from the ISO registry');
+        assertEqual(Boolean(library.get('setup_call_cleanup', 3)), true, 'setup_call_cleanup/3 is an EyeProlog cleanup control');
         assertEqual(registeredNativeEyePrologLibraryNames().length, 41, 'public native EyeProlog builtin count');
         assertEqual(eyePrologPortableLibraryIndicators.length, 87, 'portable Prolog library count');
         assertEqual(eyePrologInteropLibraryIndicators.length, 29, 'cross-implementation interop profile count');


### PR DESCRIPTION
Resolves the follow-up in #48 about cleanup-aware choicepoints.

This change:
- adds `call_cleanup/2` and `setup_call_cleanup/3` in the normal EyeProlog profile;
- closes discarded builtin iterators when search is pruned by cut, query abandonment, or exception unwinding;
- lets cleanup iterators report when their protected goal has no pending alternatives, so the demand-driven REPL can suppress a redundant choicepoint without speculative look-ahead;
- preserves strict ISO mode by keeping these predicates outside the Part 1 registry;
- adds focused regressions for deterministic completion, stopping enumeration, cut-time bindings, exception priority, nested cleanup order, setup-once behavior, failed setup, cleanup validation, and strict mode.

Refs #48, especially issuecomment-5378183958.