### PR TITLE
Fix quad `maybe` residual-constraint answers

### DIFF
--- a/examples/book/README.md
+++ b/examples/book/README.md
@@ -250,3 +250,4 @@ npm run generate
 - [01-color.pl](chapter-40/01-color.pl) — Embedded quad tests
 - [02-program.pl](chapter-40/02-program.pl)
 - [03-program-2.pl](chapter-40/03-program-2.pl)
+- [04-program-3.pl](chapter-40/04-program-3.pl)

--- a/examples/book/chapter-40/02-program.pl
+++ b/examples/book/chapter-40/02-program.pl
@@ -1,5 +1,6 @@
 % From The Art of EyeProlog, Chapter 40.
-?- read(X).
-   inputs("1."), X = 1, unexpected.
-   inputs("1."), peeks(" "), X = 1.
-   inputs("1. "), peeks(" "), X = 1, unexpected.
+?- dif(X,Y), X = a.
+   true, unexpected.
+   X = a, unexpected.
+   X = a, maybe.
+   maybe, unexpected.

--- a/examples/book/chapter-40/03-program-2.pl
+++ b/examples/book/chapter-40/03-program-2.pl
@@ -1,5 +1,5 @@
 % From The Art of EyeProlog, Chapter 40.
-inf :- inf, inf.
-
-?- inf.
-   loops.
+?- read(X).
+   inputs("1."), X = 1, unexpected.
+   inputs("1."), peeks(" "), X = 1.
+   inputs("1. "), peeks(" "), X = 1, unexpected.

--- a/examples/book/chapter-40/04-program-3.pl
+++ b/examples/book/chapter-40/04-program-3.pl
@@ -1,0 +1,5 @@
+% From The Art of EyeProlog, Chapter 40.
+inf :- inf, inf.
+
+?- inf.
+   loops.

--- a/src/quads.js
+++ b/src/quads.js
@@ -1,6 +1,8 @@
 // Embedded quad tests: a query followed by one or more answer descriptions.
 // The syntax follows the portable "queries using answer descriptions" format
 // used by Trealla and the ISO Prolog working examples linked from issue #1.
+// A `maybe` annotation denotes a successful answer with residual constraints;
+// it does not relax the ordinary answer-substitution comparison.
 import {
   ATOM, COMPOUND, VAR, Env, atom, compound, copyResolved, deref,
   flattenConjunction, listFromItems, properListItems, termIsGround,
@@ -203,6 +205,7 @@ function describeLeaf(term) {
     sto: false,
     false: false,
     truth: false,
+    maybe: false,
     loops: false,
     waits: false,
     error: null,
@@ -218,6 +221,7 @@ function describeLeaf(term) {
       if (item.name === 'unexpected' || item.name === 'inattendue') leaf.unexpected = true;
       else if (item.name === '...' || item.name === 'ad_infinitum') leaf.more = true;
       else if (item.name === 'sto') leaf.sto = true;
+      else if (item.name === 'maybe') leaf.maybe = true;
       else if (item.name === 'loops') leaf.loops = true;
       else if (item.name === 'waits') leaf.waits = true;
       else if (item.name === 'other_answer_sequence') {
@@ -253,10 +257,11 @@ function describeLeaf(term) {
     if (isErrorDescription(item)) leaf.error = item;
     else leaf.malformed ??= item;
   }
-  leaf.hasExpectation = leaf.bindings.length > 0 || leaf.truth || leaf.false || leaf.loops || leaf.waits ||
+  leaf.hasExpectation = leaf.bindings.length > 0 || leaf.truth || leaf.false || leaf.maybe || leaf.loops || leaf.waits ||
     leaf.error != null || leaf.output != null;
   if (!leaf.hasExpectation && !leaf.more && !leaf.sto && leaf.unsupported == null) leaf.malformed ??= term;
   if ([leaf.false, leaf.truth, leaf.error != null].filter(Boolean).length > 1) leaf.malformed ??= term;
+  if (leaf.maybe && (leaf.false || leaf.loops || leaf.waits || leaf.error != null)) leaf.malformed ??= term;
   return leaf;
 }
 
@@ -386,7 +391,24 @@ function matchLeaf(program, query, leaf, actual, position) {
   }
   const solution = actual.solutions[position];
   if (!solution || !outputMatches(program, leaf.output, solution.output)) return false;
+  // Portable answer descriptions distinguish plain success from success with
+  // residual constraints. `maybe` requires at least one pending residue, while
+  // its absence requires an unconstrained answer. In either case the stated
+  // substitutions remain exact and are checked below.
+  if (leaf.maybe !== hasPendingConstraints(solution.env)) return false;
   return substitutionMatches(query, leaf.bindings, solution.env);
+}
+
+function hasPendingConstraints(env) {
+  for (const constraint of env.variableConstraints?.() ?? []) {
+    if (constraint.status?.(env) === 'pending') return true;
+  }
+  // Prolog attributed variables and delayed goals are the other residual-state
+  // mechanisms exposed by call_residue_vars/2. Treat either as pending residue
+  // even when a library does not provide a printable projection goal.
+  if ((env.attributedVariableNames?.() ?? []).length > 0) return true;
+  if ((env.delayedVariableNames?.() ?? []).length > 0) return true;
+  return false;
 }
 
 function descriptionDeclaresSto(description) {

--- a/test/run-regression.mjs
+++ b/test/run-regression.mjs
@@ -2006,6 +2006,25 @@ c4 ?- call((!;1)).
       },
     },
     {
+      name: 'runQuads maybe requires pending constraints without weakening substitutions (issue #80)',
+      run: () => {
+        const result = publicApi.runQuads(`37
+?- dif(X,Y), X = a.
+   true, unexpected.
+   X = a, unexpected.
+   X = a, maybe.
+   maybe, unexpected.
+
+?- X = a.
+   X = a, maybe, unexpected.
+`);
+        assertEqual(result.total, 5, 'quad total');
+        assertEqual(result.passed, 5, 'quad passed');
+        assertEqual(result.failed, 0, 'quad failed');
+        assertEqual(result.stdout, 'quads: 5 run, 5 passed, 0 failed.\n', 'quad report');
+      },
+    },
+    {
       name: 'runQuads rejects malformed answer substitutions',
       run: () => {
         const source = `?- X = f(Y), Y = 1.\n   X = f(Y), Y = 1.\n`;

--- a/the-art-of-eyeprolog.md
+++ b/the-art-of-eyeprolog.md
@@ -7045,7 +7045,23 @@ is its synonym). Variables named in the query keep their identity inside answer
 descriptions; variables introduced only by a description are fresh. For example,
 a query `throw(g(X))` is described by `throw(g(_X))`, while
 `throw(g(X)), unexpected` verifies that ISO `throw/1` did not retain the query
-variable in the renamed exception term. `...` and `ad_infinitum` accept further answers. Multiple
+variable in the renamed exception term. `...` and `ad_infinitum` accept further answers. The `maybe` annotation describes
+a successful answer that still has at least one pending residual constraint. It
+does not stand for an arbitrary answer and it does not weaken substitution
+matching: `X = a, maybe` still requires the `X = a` substitution. Conversely, a
+successful answer description without `maybe` requires that no residual
+constraint remain. For example, a pending `dif/2` constraint can be checked as:
+
+```eyeprolog
+?- dif(X,Y), X = a.
+   true, unexpected.
+   X = a, unexpected.
+   X = a, maybe.
+   maybe, unexpected.
+```
+
+EyeProlog treats native variable constraints, attributed-variable residue, and
+delayed goals as pending residue for this purpose. Multiple
 indented descriptions after one query are independent checks: each re-runs the
 query, each is counted in the `quads:` summary, and a failing description does
 not suppress later descriptions for that query. `inputs/1` supplies and checks


### PR DESCRIPTION
Fixes #80.

- recognize `maybe` in portable quad answer descriptions
- require pending residual state when `maybe` is present
- require no residual state when it is absent
- keep answer-substitution matching exact
- count native variable constraints, attributed-variable residue, and delayed goals
- add the issue #80 regression case plus an unconstrained negative guard
- document the semantics and regenerate the affected book examples

Validation on the attached/current source snapshot: `npm test` passes 1998/1998 tests.